### PR TITLE
Initial Zenodo Refs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,38 @@
+{
+    "title": "SOLARNET Metadata Recommendations for Solar Observations",
+    "description": "This document describes the metadata recommendations developed under the SOLARNET EU project, which aims to foster more collaboration and data sharing between both ground-based and space-based Solar observatories.",
+    "creators": [
+        {
+            "name": "Haugan, Stein Vidar Hagfors",
+            "affiliation": "Institute of Theoretical Astrophysics, University of Oslo",
+            "orcid": "0000-0001-9648-7260"
+        },
+        {
+            "name": "Fredvik, Terje",
+            "affiliation": "Institute of Theoretical Astrophysics, University of Oslo",
+            "orcid": "0000-0002-8673-3920"
+        }
+    ],
+    "license": "CC-BY-4.0",
+    "keywords": [
+        "SOLARNET",
+        "metadata",
+        "solar observations",
+        "FITS"
+    ],
+    "related_identifiers": [
+        {
+            "relation": "continues",
+            "identifier": "https://zenodo.org/records/5719255"
+        },
+        {
+            "relation": "continues",
+            "identifier": "https://arxiv.org/abs/2011.12139"
+        }
+    ],
+    "communities": [
+        {
+            "identifier": "solarnet"
+        }
+    ]
+}


### PR DESCRIPTION
This is to add Zenodo references in the repository. Zenodo has a GitHub integration so that when we create releases, they will generate new DOIs on Zenodo. The project will also have a project-level DOI that can be used across all versions. 

I've tested with this on the Sandbox Zenodo and it works pretty well. I'm also following the same process for the SAMMI project for CDF/ISTP attributes so they will have a similar setup. https://github.com/swxsoc/sammi/pull/20, https://github.com/swxsoc/sammi/issues/18

Please double-check the information in the `.zenodo.json` this this will determine how the DOI references creators and affiliations. 