### PR TITLE
Revamp User Guide Documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Latest
 * Added build configuration with ``pyproject.toml`` for modern Python packaging
 * Added pre-commit configuration for code quality
 * Converted Section 19 Keyword List generation. 
+    * Added "Required" column to keyword listing in Section 19
     * Previously, this keyword list was generated using a CSV file and some python code to generate the "Section Reference" list. 
     * This CSV file has been replaced with the larger "schema" YAML file, which contains a larger set of metadata about each keyword. The Python code for generating the keyword list in Section 19 has been updated to read from this schema file.
     * Future updates to add or remove keywords should be done in the schema file. `solarnet_metadata/data/SOLARNET_attr_schema.yaml`

--- a/docs/keyword_processor.py
+++ b/docs/keyword_processor.py
@@ -168,7 +168,13 @@ def generate_keyword_csv(solarnet_keywords, output_path):
                 else ""
             )
             writer.writerow(
-                [keyword, data["origin"], data["description"], formatted_refs]
+                [
+                    f"`{keyword}`",
+                    f"`{data['origin']}`",
+                    data["description"],
+                    f"`{data['required']}`",
+                    formatted_refs,
+                ]
             )
 
 

--- a/docs/source/partc.md
+++ b/docs/source/partc.md
@@ -9,10 +9,16 @@ Keyword origins are defined using a code:
 - `P`: Keywords defined in Paper I-V and Thompson (2006)[^footnote-18].
 - `O`: Other keywords in common use before being specified in this document
 
+Keyword requirements are defined as:
+- `all`: Required for all FITS headers
+- `primary`: Required for primary header
+- `obs`: Required for observation headers
+- `optional`: Optional
+
 ```{csv-table} Solarnet keywords
 :header: >
-:   "Keyword", "Origin", "Description", "Section Reference"
-:widths: 10 5 30 15
+:   "Keyword", "Origin", "Description", "Required", "Section Reference"
+:widths: 5 5 30 5 15
 :file: solarnet_keyword_list.csv
 ```
 

--- a/docs/user-guide/acknowledging.rst
+++ b/docs/user-guide/acknowledging.rst
@@ -1,8 +1,8 @@
 .. _acknowledging:
 
-***************************************************************
-Acknowledging the SOLARNET Metadata Package and Recommendations
-***************************************************************
+*******************************************
+Acknowledging the SOLARNET Metadata Project
+*******************************************
 
 The SOLARNET Metadata Recommendations for Solar Observations have been developed to standardize metadata descriptions of solar observations, facilitating better data sharing and collaboration between ground-based and space-based solar observatories.
 
@@ -26,4 +26,4 @@ If you use the SOLARNET Metadata Recommendations in your work, we kindly ask tha
     :target: https://arxiv.org/abs/2011.12139v4
     :alt: arXiv
 
-Citing this reference helps to spread awareness of the SOLARNET Metadata Package's capabilities and gives credit to those who have contributed.
+Citing this reference helps to spread awareness of the SOLARNET Metadata Projects's capabilities and gives credit to those who have contributed.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -11,6 +11,7 @@ This guide provides an overview of how to use the SOLARNET metadata schema, incl
    :maxdepth: 2
 
    install_guide
-   solarnet_keyword_schema
+   templates
    validation
+   solarnet_schema_customization
    acknowledging

--- a/docs/user-guide/install_guide.rst
+++ b/docs/user-guide/install_guide.rst
@@ -1,11 +1,11 @@
-.. install_guide
+.. _install_guide:
 
 ************************************
 Installing SOLARNET Metadata Package
 ************************************
 
-Overview
-========
+Installation Overview
+=====================
 
 .. note::
     **Beta Development Notice**: The SOLARNET Metadata Package is currently in beta development and not yet available on PyPI. 

--- a/docs/user-guide/solarnet_schema_customization.rst
+++ b/docs/user-guide/solarnet_schema_customization.rst
@@ -1,8 +1,8 @@
-.. solarnet_keyword_schema:
+.. _solarnet_schema_customization:
 
-*********************************************
-Using SOLARNET Schema for Metadata Attributes
-*********************************************
+*******************************
+Customizing the SOLARNET Schema
+*******************************
 
 Overview
 ========
@@ -61,14 +61,15 @@ Here's an example of the schema file format:
 
   attribute_key:
     attribute_name:
-      data_type: <string> 
+      data_type: <string> # one of ['int', 'float', 'str', 'date', 'bool']
       default: <Any> | null 
       description: >
         Include a meaningful description of the attribute and context needed to understand its values.
-      human_readable: <string>
-      required: <bool>
+      human_readable: <string> # Provides a default value for the keyword comment
+      required: <string> # one of ['all', 'primary', 'obs', 'optional']
       valid_values: optional[list]
       pattern: optional[string]  # For attributes with variable indices (e.g., NAXISn, CTYPEia)
+      origin: <string> # one of ['N', 'S', 'P', 'O'] (for more information, see Section 19)
   conditional_requirements:
     - condition_type: <string>
       condition_key: <string>
@@ -78,7 +79,7 @@ Here's an example of the schema file format:
 Each of the keys for the :py:attr:`attribute_key` section is defined in the table below:
 
 .. list-table:: Attribute Schema Keys
-  :widths: 20 50 10 10
+  :widths: 10 50 10 10
   :header-rows: 1
 
   * - Schema Key
@@ -90,7 +91,7 @@ Each of the keys for the :py:attr:`attribute_key` section is defined in the tabl
     - `str`
     - `True`
   * - `data_type`
-    - the expected data type of the attribute (`int`, `float`, `str`, `date`)
+    - the expected data type of the attribute (`int`, `float`, `str`, `date`, `bool`)
     - `str`
     - `True`
   * - `default`
@@ -106,7 +107,7 @@ Each of the keys for the :py:attr:`attribute_key` section is defined in the tabl
     - `str`
     - `True`
   * - `required`
-    - whether the attribute is required in your data products (`primary`, `obs`, `optional`)
+    - whether the attribute is required in your data products (`all`, `primary`, `obs`, `optional`)
     - various
     - `True`
   * - `valid_values`
@@ -117,11 +118,19 @@ Each of the keys for the :py:attr:`attribute_key` section is defined in the tabl
     - regular expression pattern for attributes with variable indices (e.g., NAXISn, CTYPEia)
     - `str`
     - `False`
+  * - `origin`
+    - indicates the origin of the keyword attribute. For more information, see :ref:`19.0`
+    - `str`
+    - `True`
+
 
 The :py:attr:`conditional_requirements` section defines when certain attributes are required based on other attribute values:
 
+This functionality allows you to specify that certain attributes are only required when specific conditions are met, such as the value of another attribute.
+This section is still under development and is planned to be expanded in future releases.
+
 .. list-table:: Conditional Requirements Schema
-  :widths: 20 50 10 10
+  :widths: 10 50 10 10
   :header-rows: 1
 
   * - Schema Key
@@ -158,60 +167,6 @@ For example, the schema includes conditional requirements based on observatory t
       - OBSGEO-Z
 
 This specifies that when `OBS_TYPE==ground-based`, the `OBSGEO-X`, `OBSGEO-Y`, and `OBSGEO-Z` attributes are required.
-
-Using the SOLARNET Schema
-=========================
-
-The SOLARNET Schema provides several useful methods for working with metadata attributes:
-
-Getting Attribute Information
------------------------------
-
-You can retrieve detailed information about specific attributes or all attributes using the `attribute_info()` method:
-
-.. code-block:: python
-
-  # Create a schema object
-  schema = SOLARNETSchema(use_defaults=True)
-  
-  # Get information about a specific attribute
-  author_info = schema.attribute_info(attribute_name="AUTHOR")
-  
-  # Get information about all attributes
-  all_info = schema.attribute_info()
-
-This returns an astropy Table containing all the schema information for the requested attribute(s).
-
-Creating Attribute Templates
-----------------------------
-
-You can generate a template of required attributes based on observatory and instrument types:
-
-.. code-block:: python
-
-  # Create a schema object
-  schema = SOLARNETSchema(use_defaults=True)
-  
-  # Get a template for ground-based imager
-  template = schema.attribute_template(
-    observatory_type="ground-based",
-    instrument_type="Imager"
-  )
-
-This returns a dictionary where keys are required attribute names and values are None. You can then fill in the appropriate values for your data.
-
-Accessing Default Attributes
-----------------------------
-
-You can access the default attributes directly:
-
-.. code-block:: python
-
-  # Create a schema object
-  schema = SOLARNETSchema(use_defaults=True)
-  
-  # Get the default attributes
-  defaults = schema.default_attributes
 
 Creating and Using Attribute Files
 ==================================

--- a/docs/user-guide/templates.rst
+++ b/docs/user-guide/templates.rst
@@ -1,0 +1,115 @@
+.. _templates:
+
+***************************
+SOLARNET Metadata Templates
+***************************
+
+The SOLARNET Schema provides several useful methods for working with metadata attributes. 
+
+- **Keyword Templates:** :py:class:`astropy.io.fits.Header` objects can be created as templates based on input options, where the header contains all default and required attributes with empty values. 
+    - This enables users to easily fill in the necessary metadata for their data products in an partially populated FITS header format.
+- **Keyword Detail Information:** You can also retrieve detailed information about specific attributes or all attributes in the schema. 
+    - This is useful for understanding the requirements and context of each metadata attribute.
+    - An :py:class:`astropy.table.Table` is returned, which can be easily viewed or exported to various formats (e.g., CSV, HTML).
+
+Creating Attribute Templates
+============================
+
+Attributes templates are created using the :py:meth:`~solarnet_metadata.schema.SOLARNETSchema.attribute_template` method of the :py:class:`~solarnet_metadata.schema.SOLARNETSchema` class.
+This method allows you to generate a template :py:class:`astropy.io.fits.Header` object populated with all required keywords, and values set to :py:attr:`None`.
+
+This can serve as a useful tool for prototyping FITS header metadata that is compliant with the SOLARNET metadata standards.
+Users can fill in the appropriate values for required attributes, and add optional attributes as needed to their headers. 
+
+Options available for generating templates include:
+
+- :py:attr:`primary` (bool): If :py:attr:`True`, the template will include keywords required for primary HDUs.
+- :py:attr:`obs` (bool): If :py:attr:`True`, the template will include keywords required for observation HDUs.
+- :py:attr:`observatory_type` (str): You can specify the type of observatory to include observatory-specific required keywords.
+    - This must be one of ``["ground-based", "earth-orbiting", "deep-space"]``
+- :py:attr:`instrument_type` (str): You can specify the type of instrument to include instrument-specific required keywords.
+    - This must be one of ``["Imager", "Spectrograph"]``
+
+.. code-block:: python
+
+    from astropy.io import fits
+    from solarnet_metadata.schema import SOLARNETSchema
+
+    # Create a schema object
+    schema = SOLARNETSchema(use_defaults=True)
+    
+    # Get a template for ground-based imager
+    template: fits.Header = schema.attribute_template(
+        primary=True,
+        obs=True,
+        observatory_type="ground-based",
+        instrument_type="Imager"
+    )
+
+This returns a :py:class:`astropy.io.fits.Header` object where keys are required attribute names and values are :py:attr:`None`. You can then fill in the appropriate values for your data.
+
+
+Getting Attribute Information
+=============================
+
+You can retrieve detailed information about specific attributes or all attributes using the `attribute_info()` method of the :py:class:`~solarnet_metadata.schema.SOLARNETSchema` class.
+
+This method returns an :py:class:`astropy.table.Table` containing the attribute information.
+
+Details provided include:
+
+- Attribute name
+- :py:attr:`data_type` (str): The expected data type of the attribute value.
+- :py:attr:`default` (Any | None): The default value for the attribute, if any.
+- :py:attr:`description` (str): A description of the attribute and its context.
+- :py:attr:`human_readable` (str): Provides a default value for the keyword comment.
+- :py:attr:`required` (str): Indicates if the attribute is required
+- :py:attr:`origin` (str): Indicates the origin of the keyword attribute. For more information, see :ref:`19.0`
+- :py:attr:`pattern` (str | None): For attributes with variable indices (e.g., NAXISn, CTYPEia), the pattern used to generate the attribute names.
+- :py:attr:`valid_values` (list | None): A list of valid values for the attribute, if applicable.
+
+You can optionally specify an attribute name with the :py:attr:`attribute_name` parameter to get information about a specific attribute.
+
+
+For more information on the values provided, see the table in the :ref:`Attribute Schema Format <solarnet_schema_customization>` section.
+
+.. code-block:: python
+
+    from astropy.table import Table
+    from solarnet_metadata.schema import SOLARNETSchema
+
+    # Create a schema object
+    schema = SOLARNETSchema(use_defaults=True)
+    
+    # Get information about a specific attribute
+    author_info: Table = schema.attribute_info(attribute_name="AUTHOR")
+    
+    # Get information about all attributes
+    all_info: Table = schema.attribute_info()
+
+This returns an :py:class:`astropy.table.Table` containing all the schema information for the requested attribute(s).
+
+
+Accessing Default Attributes
+=============================
+
+Default attributes can be specified in the schema for attributes that have a common default value.
+These default values are loaded in the schema upon instantiation and are available through the :py:attr:`default_attributes` property of the :py:class:`~solarnet_metadata.schema.SOLARNETSchema` class.
+
+The :py:attr:`default_attributes` property returns a :py:class:`astropy.fits.Header` object containing all attributes that have a specified default value in the schema, with their values set to the defined default.
+
+The default attributes are included in the attribute templates generated by the :py:meth:`~solarnet_metadata.schema.SOLARNETSchema.attribute_template` method, with their values set to the specified default.
+
+.. code-block:: python
+
+    from astropy.io import fits
+    from solarnet_metadata.schema import SOLARNETSchema
+
+    # Create a schema object
+    schema = SOLARNETSchema(use_defaults=True)
+    
+    # Get the default attributes
+    defaults: fits.Header = schema.default_attributes
+
+This can be useful for quickly populating a FITS header with common default values for required attributes in your data files.
+The returned :py:class:`astropy.fits.Header` object can be easily manipulated or converted to other formats as needed.

--- a/docs/user-guide/validation.rst
+++ b/docs/user-guide/validation.rst
@@ -1,8 +1,8 @@
-.. validation:
+.. _validation:
 
-*****************************************************
-Using SOLARNET Validator for FITS Metadata Validation
-*****************************************************
+****************************
+SOLARNET Metadata Validation
+****************************
 
 Overview
 ========
@@ -10,17 +10,36 @@ Overview
 The SOLARNET :py:mod:`solarnet_metadata.validation` module provides tools to validate FITS files against the SOLARNET metadata schema requirements.
 This ensures that your FITS files conform to the required standards and helps identify any issues with the metadata attributes.
 
+The validation functions, without any additional options enabled, will validate FITS files and headers against the baseline SOLARNET schema requirements. 
+For more stringent validation checks, you can enable additional warning options as needed. 
+For validation against custom schema requirements, for example, if you have added custom mission-specific keywords, you can provide a custom schema to the validation functions. 
+For more information on customizing the schema, see :ref:`solarnet_schema_customization`.
+
 The validation process checks for:
 
-- Required keywords based on HDU type (primary, observation)
-- Pattern-based keywords when specified in the schema
+- Required FITS and SOLARNET keywords must be included based on HDU type (primary, observation)
 - Proper formatting of keywords, values, and comments
-- Correct data types for keyword values
+    - Keywords must be:
+        - 1-8 characters in length
+        - Contain only uppercase letters, digits, hyphens, and underscores  (A-Z, 0-9, -, _)
+    - Values must be castable to string data types for inclusion in FITS headers
+    - Comments must be castable to string data types for inclusion in FITS headers
+    - The total FITS header line length (keyword + value + comment) must not exceed 80 characters
+- Keyword values must match one of the expected valid values if specified in the schema
+- Keyword values must match or be castable to the expected data type as defined in the schema
 
 Using the Validation Functions
 ==============================
 
 The main validation function is :py:func:`~solarnet_metadata.validation.validate_file`, which validates an entire FITS file.
+
+This function returns a list of findings, which are strings describing any issues found during validation. 
+If no issues are found, the list will be empty. 
+Rather than raising exceptions for validation issues, the function collects all findings and returns them as a list. 
+This allows you to see all issues at once rather than stopping at the first error. 
+This can be extended in individual data processing pipelines to issue warnings or raise exceptions as needed.
+
+The function assumes that the FITS file is structured according to standard FITS conventions, with a primary HDU and optional additional HDUs.
 
 .. code-block:: python
 
@@ -34,17 +53,19 @@ The main validation function is :py:func:`~solarnet_metadata.validation.validate
     validation_findings: List[str] = validate_file(fits_path)
 
     # Print the validation findings
-    if validation_findings:
-        print("Validation issues found:")
-        for finding in validation_findings:
-            print(finding)
-    else:
-        print("No validation issues found.")
+    print("Validation issues found:")
+    for finding in validation_findings:
+        print(finding)
+
 
 Validation Options
 ------------------
 
 The validation functions accept several parameters to control the validation process:
+- :py:attr:`warn_empty_keyword` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that contain empty strings as values.
+- :py:attr:`warn_no_comment` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that are missing comments.
+- :py:attr:`warn_data_type` (bool): If :py:attr:`True`, the validator will check that keyword values match the expected data types defined in the schema.
+- :py:attr:`schema` (:py:class:`~solarnet_metadata.schema.SOLARNETSchema`): You can provide a custom schema instance to validate against custom requirements. If not provided, the default SOLARNET schema will be used.
 
 .. code-block:: python
 
@@ -59,7 +80,7 @@ The validation functions accept several parameters to control the validation pro
     custom_schema = SOLARNETSchema()
 
     # Validate with all warning options enabled
-    validation_findings = validate_file(
+    validation_findings: List[str] = validate_file(
         file_path=fits_path,
         warn_empty_keyword=True,    # Report warnings for empty keywords
         warn_no_comment=True,       # Report warnings for missing comments
@@ -67,10 +88,21 @@ The validation functions accept several parameters to control the validation pro
         schema=custom_schema        # Use custom schema (optional)
     )
 
+
 Validating Individual Headers
 -----------------------------
 
-If you need to validate just a single FITS header, you can use the :py:func:`~solarnet_metadata.validation.validate_header` function:
+If you need to validate just a single FITS header, you can use the :py:func:`~solarnet_metadata.validation.validate_header` function.
+
+This function takes an :py:class:`astropy.io.fits.Header` object and validates it against the schema requirements.
+
+Specific options available for this function include:
+- :py:attr:`is_primary` (bool): Set to :py:attr:`True` if the header is from a primary HDU, or :py:attr:`False` if it is from an observation HDU. This determines which keywords are required based on HDU type.
+- :py:attr:`is_obs` (bool): Set to :py:attr:`True` if the header is from an observation HDU, or :py:attr:`False` if it is from a primary HDU. This determines which keywords are required based on HDU type. It is possible to set both :py:attr:`is_primary` and :py:attr:`is_obs` to :py:attr:`True` if the header is from a primary observation HDU.
+- :py:attr:`warn_empty_keyword` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that contain empty strings as values.
+- :py:attr:`warn_no_comment` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that are missing comments.
+- :py:attr:`warn_data_type` (bool): If :py:attr:`True`, the validator will check that keyword values match the expected data types defined in the schema.
+- :py:attr:`schema` (:py:class:`~solarnet_metadata.schema.SOLARNETSchema`): You can provide a custom schema instance to validate against custom requirements. If not provided, the default SOLARNET schema will be used.
 
 .. code-block:: python
 
@@ -80,17 +112,18 @@ If you need to validate just a single FITS header, you can use the :py:func:`~so
     # Open the FITS file and get the header
     with fits.open("/path/to/your/file.fits") as hdul:
         # Validate the primary header
-        primary_findings = validate_header(
+        primary_findings: List[str] = validate_header(
             header=hdul[0].header,
             is_primary=True,
+            is_obs=False,
             warn_data_type=True
         )
         
-        # Print primary header findings
-        if primary_findings:
-            print("Primary header issues:")
-            for finding in primary_findings:
-                print(finding)
+    # Print primary header findings
+        print("Primary header issues:")
+        for finding in primary_findings:
+            print(finding)
+
 
 Validating Keyword Format
 -------------------------
@@ -107,7 +140,7 @@ You can validate individual FITS keywords, values, and comments using the :py:fu
     comment = "Telescope name"
 
     # Validate the keyword, value, and comment
-    findings = validate_fits_keyword_value_comment(
+    findings: List[str] = validate_fits_keyword_value_comment(
         keyword=keyword, 
         value=value, 
         comment=comment,
@@ -115,10 +148,10 @@ You can validate individual FITS keywords, values, and comments using the :py:fu
         warn_no_comment=True
     )
     
-    if findings:
-        print("Validation issues:")
-        for finding in findings:
-            print(finding)
+    print("Validation issues:")
+    for finding in findings:
+        print(finding)
+
 
 Checking Data Types
 -------------------
@@ -130,21 +163,20 @@ To validate the data type of a keyword value against the schema:
     from solarnet_metadata.validation import validate_fits_keyword_data_type
     from solarnet_metadata.schema import SOLARNETSchema
 
-    # Create a schema instance
-    schema = SOLARNETSchema()
+    # Optionally, create a custom schema instance
+    custom_schema = SOLARNETSchema()
 
     # Example keyword and value
     keyword = "EXPTIME"
     value = 10.5
 
     # Validate the data type
-    findings = validate_fits_keyword_data_type(
+    findings: List[str] = validate_fits_keyword_data_type(
         keyword=keyword,
         value=value,
-        schema=schema
+        schema=custom_schema
     )
     
-    if findings:
-        print("Data type issues:")
-        for finding in findings:
-            print(finding)
+    print("Data type issues:")
+    for finding in findings:
+        print(finding)

--- a/solarnet_metadata/data/SOLARNET_attr_schema.yaml
+++ b/solarnet_metadata/data/SOLARNET_attr_schema.yaml
@@ -831,12 +831,12 @@ attribute_key:
     human_readable: Number of axes
     required: obs # Fundamental WCS coordinate keywords (sections 15, 3.1)
     origin: S
-  NASIXn:
+  NAXISn:
     pattern: NAXIS(?P<n>[1-9])
     data_type: int
     default: null
     description: The NAXISn keywords must be present for all values n = 1,... , NAXIS, in increasing order of n, and for no other values of n. The value field of this indexed keyword shall contain a non-negative integer representing the number of elements along Axis n of a data array. A value of zero for any of the NAXISn signifies that no data follow the header in the HDU (however, the random-groups structure described in Sect. 6 has NAXIS1 = 0, but will have data following the header if the other NAXISn keywords are non-zero). If NAXIS is equal to 0, there shall not be any NAXISn keywords.
-    human_readable: Number of elements along axis
+    human_readable: Number of elements along axis `n`
     required: obs
     origin: S
   NBIN:

--- a/solarnet_metadata/schema.py
+++ b/solarnet_metadata/schema.py
@@ -286,11 +286,15 @@ class SOLARNETSchema:
         metadata attribute. The Table contains all information in the SOLARNET attribute schema including:
 
         - attribute: (`str`) The name of the attribute
-        - data_type: (`str`) The data type of the attribute        
+        - data_type: (`str`) The data type of the attribute
         - default: (`str`) The default value used if none is provided
         - description: (`str`) A description of the attribute and its context
         - human_readable: (`str`) A human-readable version of the attribute name
-        - required: (`str`) Whether the attribute is required by SOLARNET standards
+        - required: (`str`) Indicates the requirement level for the attribute. Possible values are:
+            - 'all': required for all data
+            - 'primary': required for primary data
+            - 'obs': required for observational data
+            - 'optional': not required, optional attribute
         - origin: (`str`) The origin of the attribute
         - valid_values: (`list`) A list of valid values for the attribute
         - pattern: (`str`) A regex pattern that the attribute value must match

--- a/solarnet_metadata/schema.py
+++ b/solarnet_metadata/schema.py
@@ -285,9 +285,15 @@ class SOLARNETSchema:
         Function to generate an `astropy.table.Table` of information about each
         metadata attribute. The Table contains all information in the SOLARNET attribute schema including:
 
-        - description: (`str`) A brief description of the attribute
+        - attribute: (`str`) The name of the attribute
+        - data_type: (`str`) The data type of the attribute        
         - default: (`str`) The default value used if none is provided
-        - required: (`bool`) Whether the attribute is required by SOLARNET standards
+        - description: (`str`) A description of the attribute and its context
+        - human_readable: (`str`) A human-readable version of the attribute name
+        - required: (`str`) Whether the attribute is required by SOLARNET standards
+        - origin: (`str`) The origin of the attribute
+        - valid_values: (`list`) A list of valid values for the attribute
+        - pattern: (`str`) A regex pattern that the attribute value must match
 
         Parameters
         ----------


### PR DESCRIPTION
resolves #48 

  * Fixed cross-reference labels in RST files using proper underscore prefix syntax
  * Split schema documentation into separate sections:
      * Added new ``templates.rst`` guide for working with SOLARNET metadata templates 
      * Renamed ``solarnet_keyword_schema.rst`` to ``solarnet_schema_customization.rst`` with improved focus
  * Enhanced schema documentation to accurately reflect YAML implementation:
      * Updated ``required`` field documentation to show string values instead of boolean
      * Added documentation for ``origin`` field with proper cross-references to Section 19
      * Clarified data type descriptions and value formats
  * Improved keyword reference table:
      * Added "Required" column to keyword listing in Section 19
      * Enhanced table formatting with backticks for better readability
  * Fixed schema typo: corrected ``NASIXn`` to ``NAXISn`` in schema definition file