### PR TITLE
Add Ability to Warn for Missing Optional Keywords in Validation

### DIFF
--- a/docs/user-guide/validation.rst
+++ b/docs/user-guide/validation.rst
@@ -65,6 +65,7 @@ The validation functions accept several parameters to control the validation pro
 - :py:attr:`warn_empty_keyword` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that contain empty strings as values.
 - :py:attr:`warn_no_comment` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that are missing comments.
 - :py:attr:`warn_data_type` (bool): If :py:attr:`True`, the validator will check that keyword values match the expected data types defined in the schema.
+- :py:attr:`warn_missing_optional` (bool): If :py:attr:`True`, the validator will issue warnings for optional keywords that aren't included, encouraging more complete metadata.
 - :py:attr:`schema` (:py:class:`~solarnet_metadata.schema.SOLARNETSchema`): You can provide a custom schema instance to validate against custom requirements. If not provided, the default SOLARNET schema will be used.
 
 .. code-block:: python
@@ -79,12 +80,13 @@ The validation functions accept several parameters to control the validation pro
     # Custom schema (optional)
     custom_schema = SOLARNETSchema()
 
-    # Validate with all warning options enabled
+    ## Validate with all warning options enabled
     validation_findings: List[str] = validate_file(
         file_path=fits_path,
         warn_empty_keyword=True,    # Report warnings for empty keywords
         warn_no_comment=True,       # Report warnings for missing comments
         warn_data_type=True,        # Validate data types against schema
+        warn_missing_optional=True, # Report warnings for missing optional keywords
         schema=custom_schema        # Use custom schema (optional)
     )
 
@@ -102,6 +104,7 @@ Specific options available for this function include:
 - :py:attr:`warn_empty_keyword` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that contain empty strings as values.
 - :py:attr:`warn_no_comment` (bool): If :py:attr:`True`, the validator will issue warnings for any keywords that are missing comments.
 - :py:attr:`warn_data_type` (bool): If :py:attr:`True`, the validator will check that keyword values match the expected data types defined in the schema.
+- :py:attr:`warn_missing_optional` (bool): If :py:attr:`True`, the validator will issue warnings for optional keywords that aren't included.
 - :py:attr:`schema` (:py:class:`~solarnet_metadata.schema.SOLARNETSchema`): You can provide a custom schema instance to validate against custom requirements. If not provided, the default SOLARNET schema will be used.
 
 .. code-block:: python
@@ -116,7 +119,8 @@ Specific options available for this function include:
             header=hdul[0].header,
             is_primary=True,
             is_obs=False,
-            warn_data_type=True
+            warn_data_type=True,
+            warn_missing_optional=True,
         )
         
     # Print primary header findings

--- a/solarnet_metadata/schema.py
+++ b/solarnet_metadata/schema.py
@@ -197,6 +197,22 @@ class SOLARNETSchema:
         }
         return required_attributes
 
+    def get_optional_keywords(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Function to get a list of optional keywords.
+
+        Returns
+        -------
+        optional_keywords : `Dict[str, Dict[str, Any]]`
+            A dictionary of optional keywords and their associated information.
+        """
+        optional_attributes = {
+            keyword: info
+            for keyword, info in self.attribute_key.items()
+            if KeywordRequirement(info["required"]) == KeywordRequirement.OPTIONAL
+        }
+        return optional_attributes
+
     def attribute_template(
         self,
         primary: Optional[bool] = False,


### PR DESCRIPTION
- New validation parameter `warn_missing_optional` for encouraging more comprehensive metadata inclusion
  - When enabled, validation will generate warnings for optional SOLARNET keywords that aren't included in FITS headers
  - Supports both standard keywords and pattern-matched keywords
  - Available in both `validate_file()` and `validate_header()` functions
  - Set to `False` by default to maintain backward compatibility
- Added `get_optional_keywords()` method to `SOLARNETSchema` class to support optional keyword validation
- Updated documentation with examples of the new validation parameter
- Extended test suite with additional test cases for optional keyword validation
