### PR TITLE
Fix Numpy Version for Compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 This project uses `semantic versioning <https://semver.org>`_. 
 
+3.2.3
+=====
+
+* Addresses NumPy compatibility issues with Astropy 6.1.Z by adding a NumPy version constraint to prevent installation of NumPy 2.4.Z and later, which deprecate functionality required by Astropy. This ensures the package remains compatible with Python 3.10.
+
 3.2.2
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  'pyyaml>=5.3.1',
   'astropy==6.1.*',
+  'numpy==2.2.*',
+  'pyyaml>=5.3.1',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   'astropy==6.1.*',
-  'numpy==2.2.*',
+  'numpy<2.4',
   'pyyaml>=5.3.1',
 ]
 


### PR DESCRIPTION
Numpy v2.4.Z deprecates some functionality required by Astropy 6.1.Z. If we want to maintain compatibility with Python 3.10, we must stay on Astropy 6.1.Z. Python 3.10 was deprecated for Astropy 7.0. However, Astropy 6.1.Z does not set a max version requirement for numpy, so we end up installing a version with deprecated functionality. This PR sets a max NumPy version so that Astropy can function as intended. 