### PR TITLE
Update Card Length Validation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
         pip install -e .[test]
 
     - name: Run Tests
-      run: pytest --pyargs solarnet_metadata --cov --junitxml=junit.xml -o junit_family=legacy solarnet_metadata
+      run: pytest --pyargs solarnet_metadata --cov=solarnet_metadata --junitxml=junit.xml -o junit_family=legacy
       env:
         PLATFORM: ${{ matrix.platform }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,11 +33,12 @@ jobs:
         pip install -e .[test]
 
     - name: Run Tests
-      run: pytest --pyargs solarnet_metadata --cov solarnet_metadata
+      run: pytest --pyargs solarnet_metadata --cov --junitxml=junit.xml -o junit_family=legacy solarnet_metadata
       env:
         PLATFORM: ${{ matrix.platform }}
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ This project uses `semantic versioning <https://semver.org>`_.
 Latest
 ======
 
-* Fixed FITS card length validation to correctly handle keywords without comments. Previously, the validator incorrectly assumed all keywords had comments and added `/ ` separator when calculating card length, causing false positives for valid 80-character cards without comments.
+* Fixed FITS card length validation to correctly handle keywords without comments. Previously, the validator incorrectly assumed all keywords had comments and added ``/`` separator when calculating card length, causing false positives for valid 80-character cards without comments.
 * Fixed FITS card length validation to properly account for quotes around string values. The validator now adds quotes to string values when constructing the card representation, matching the actual FITS format and ensuring accurate length calculations.
 * Updated CI workflow to upload test results to Codecov using ``codecov/test-results-action@v1`` for improved test reporting and coverage tracking.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 This project uses `semantic versioning <https://semver.org>`_. 
 
+Latest
+======
+
+* Fixed FITS card length validation to correctly handle keywords without comments. Previously, the validator incorrectly assumed all keywords had comments and added `/ ` separator when calculating card length, causing false positives for valid 80-character cards without comments.
+* Fixed FITS card length validation to properly account for quotes around string values. The validator now adds quotes to string values when constructing the card representation, matching the actual FITS format and ensuring accurate length calculations.
+* Updated CI workflow to upload test results to Codecov using ``codecov/test-results-action@v1`` for improved test reporting and coverage tracking.
+
 3.2.3
 =====
 

--- a/solarnet_metadata/validation.py
+++ b/solarnet_metadata/validation.py
@@ -370,9 +370,11 @@ def validate_fits_keyword_value_comment(
             # - Column 9: '='
             # - Column 10: space
             # - Columns 11-80: value + ' / ' + comment (up to 70 characters total)
-            # String values are quoted in FITS cards
+            # String values are quoted in FITS cards. Embedded single quotes are doubled
+            # per FITS rules (e.g., O'Brien -> 'O''Brien').
             if isinstance(value, str):
-                value_str = f"'{value_str}'"
+                escaped_value_str = value_str.replace("'", "''")
+                value_str = f"'{escaped_value_str}'"
 
             # Build card with or without comment
             if comment is not None and str(comment).strip():

--- a/solarnet_metadata/validation.py
+++ b/solarnet_metadata/validation.py
@@ -379,7 +379,7 @@ def validate_fits_keyword_value_comment(
                 card_str = f"{keyword.ljust(8)}= {value_str} / {comment}"
             else:
                 card_str = f"{keyword.ljust(8)}= {value_str}"
-            print(card_str)
+
             if len(card_str) > 80:
                 findings.append(
                     f"FITS card for '{keyword}' exceeds 80 characters (length: {len(card_str)})."

--- a/solarnet_metadata/validation.py
+++ b/solarnet_metadata/validation.py
@@ -370,7 +370,16 @@ def validate_fits_keyword_value_comment(
             # - Column 9: '='
             # - Column 10: space
             # - Columns 11-80: value + ' / ' + comment (up to 70 characters total)
-            card_str = f"{keyword.ljust(8)}= {value_str} / {comment}"
+            # String values are quoted in FITS cards
+            if isinstance(value, str):
+                value_str = f"'{value_str}'"
+
+            # Build card with or without comment
+            if comment is not None and str(comment).strip():
+                card_str = f"{keyword.ljust(8)}= {value_str} / {comment}"
+            else:
+                card_str = f"{keyword.ljust(8)}= {value_str}"
+            print(card_str)
             if len(card_str) > 80:
                 findings.append(
                     f"FITS card for '{keyword}' exceeds 80 characters (length: {len(card_str)})."


### PR DESCRIPTION
- Fixed FITS card length validation to correctly handle keywords without comments. Previously, the validator incorrectly assumed all keywords had comments and added `/ ` separator when calculating card length, causing false positives for valid 80-character cards without comments.
- Fixed FITS card length validation to properly account for quotes around string values. The validator now adds quotes to string values when constructing the card representation, matching the actual FITS format and ensuring accurate length calculations.

resolves #57 